### PR TITLE
Make hz_ja.vim work even if 'clipboard' option has the "unnamed" string

### DIFF
--- a/kaoriya/vim/plugins/kaoriya/plugin/hz_ja.vim
+++ b/kaoriya/vim/plugins/kaoriya/plugin/hz_ja.vim
@@ -2,7 +2,7 @@
 "
 " hz_ja.vim - Convert character between HANKAKU and ZENKAKU
 "
-" Last Change: 06-Feb-2006.
+" Last Change: 27-Aug-2015.
 " Written By:  MURAOKA Taro <koron.kaoriya@gmail.com>
 "
 " Commands:
@@ -141,7 +141,7 @@ function! s:HzjaConvertVisual(target)
   let save_regtype = getregtype('"')
   normal! gvy
   call setreg('"', HzjaConvert(@", a:target), getregtype('"'))
-  normal! gvp
+  normal! gv""p
   call setreg('"', save_regcont, save_regtype)
 endfunction
 


### PR DESCRIPTION
>`:h clipboard`
>'clipboard' オプションに "unnamed" 文字列が含まれているときには、無名レジスタ
>は "* レジスタと同じである。したがってコマンドの前に "* を付けずに選択をコピー
>し貼り付けることができる。

https://bitbucket.org/koron/vim-kaoriya/issues/1/hz_javim-doesnt-work-on-special-usage