### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,12 @@
-name: Release
+name: Build
 
 on:
   push:
-    tags: [ '**' ]
+    branches: [ '**' ]
+    tags-ignore: ['**' ]
 
 concurrency:
-  group: ci-release-${{ github.workflow }}-${{ github.ref }}
+  group: ci-build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,10 +1,6 @@
 name: Ubuntu Build
 
 on:
-  push:
-    branches: [ '**' ]
-    tags-ignore: ['**' ]
-
   workflow_call:
 
 concurrency:

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -15,7 +15,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
 
     defaults:
       run:
@@ -82,7 +82,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
 
     needs: build
 

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -27,14 +27,15 @@ jobs:
       uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
       id: msys2
       with:
-        msystem: MSYS
-        update: false
-        install: >-
-          patch
+        update: true
+        msystem: UCRT64
+        pacboy: >-
+          patch:
         release: false
 
     - name: Setup MSYS2 PATH
       run: |
+        echo ${{ steps.msys2.outputs.msys2-location }}\%MSYSTEM%\bin>> %GITHUB_PATH%
         echo ${{ steps.msys2.outputs.msys2-location }}\usr\bin>> %GITHUB_PATH%
 
     - name: Setup VC++ environment (VCVARSALL)
@@ -102,14 +103,15 @@ jobs:
       uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
       id: msys2
       with:
-        msystem: MSYS
-        update: false
-        install: >-
-          diffutils
+        update: true
+        msystem: UCRT64
+        pacbody: >-
+          diffutils:p
         release: false
 
     - name: Setup MSYS2 PATH
       run: |
+        echo ${{ steps.msys2.outputs.msys2-location }}\%MSYSTEM%\bin>> %GITHUB_PATH%
         echo ${{ steps.msys2.outputs.msys2-location }}\usr\bin>> %GITHUB_PATH%
 
     - name: Setup VC++ environment (VCVARSALL)

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
     - name: Install tools by MSYS2
-      uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
       id: msys2
       with:
         msystem: MSYS
@@ -99,7 +99,7 @@ jobs:
     steps:
 
     - name: Install tools by MSYS2
-      uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
       id: msys2
       with:
         msystem: MSYS

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -1,10 +1,6 @@
 name: Windows with MSVC
 
 on:
-  push:
-    branches: [ '**' ]
-    tags-ignore: ['**' ]
-
   workflow_call:
 
 concurrency:

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -101,7 +101,7 @@ jobs:
       with:
         update: true
         msystem: UCRT64
-        pacbody: >-
+        pacboy: >-
           diffutils:p
         release: false
 

--- a/.github/workflows/windows-ucrt64.yml
+++ b/.github/workflows/windows-ucrt64.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
 
     defaults:
       run:
@@ -92,7 +92,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
 
     needs: build
 

--- a/.github/workflows/windows-ucrt64.yml
+++ b/.github/workflows/windows-ucrt64.yml
@@ -118,6 +118,7 @@ jobs:
           diffutils:p
           make:p
           luajit:p
+          python:p
         release: false
 
     - name: Set up MSYS2 path

--- a/.github/workflows/windows-ucrt64.yml
+++ b/.github/workflows/windows-ucrt64.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Set up MSYS2 packages
-      uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
       id: msys2
       with:
         update: true
@@ -109,7 +109,7 @@ jobs:
 
     steps:
     - name: Install tools by MSYS2
-      uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
       id: msys2
       with:
         msystem: UCRT64

--- a/.github/workflows/windows-ucrt64.yml
+++ b/.github/workflows/windows-ucrt64.yml
@@ -1,10 +1,6 @@
 name: Windows with UCRT64/MSYS2
 
 on:
-  push:
-    branches: [ '**' ]
-    tags-ignore: ['**' ]
-
   workflow_call:
 
 concurrency:


### PR DESCRIPTION
- MSYS2 のセットアップをバージョンアップ
- MSYS2 (UCRT64)のパッケージインストール方法をpacboyへ変更
- インストールするパッケージをレビュー
- Windowsランナーを最新の `windows-2025-vs2026` に更新
- ワークフローの統廃合: OS違いの複数ジョブを1画面で確認できるように